### PR TITLE
Fix a few broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: Tom Preston-Werner
   <h1>Other Interviews, Talks, Etc</h1>
   <ul class="posts">
     <li><span>28 Dec 2012</span> &raquo; <a href="http://bits.blogs.nytimes.com/2012/12/28/github-has-big-dreams-for-open-source-software-and-more/">Article: NYTimes - Dreams of ‘Open’ Everything</a></li>
-    <li><span>20 Oct 2012</span> &raquo; <a href="http://startupschool.org/2012/preston_werner/">Video: Startup School 2012 - People, Product, Philosophy</a></li>
+    <li><span>20 Oct 2012</span> &raquo; <a href="http://www.youtube.com/watch?v=P9jjDpWzsUI">Video: Startup School 2012 - People, Product, Philosophy</a></li>
     <li><span>27 Sep 2012</span> &raquo; <a href="http://www.youtube.com/watch?v=Ln-B_fs9QMY&feature=youtu.be">Video (Panel): Orrick - How to Build a Great Startup Culture</a></li>
     <li><span>18 Jun 2012</span> &raquo; <a href="http://gigaom.com/cloud/10-innovators-changing-the-game-for-internet-infrastructure/7/">Article: GigaOm - 10 Innovators Changing the Game for Internet Infrastructure</a></li>
     <li><span>02 Dec 2011</span> &raquo; <a href="http://vimeo.com/35640883">Video: Northern Lights Conference - Leveling Up</a></li>
@@ -44,7 +44,7 @@ title: Tom Preston-Werner
     <li><span>17 Jun 2010</span> &raquo; <a href="http://webpulp.tv/post/708686185/github-tom-preston-werner">WebPulp.tv: Interview with GitHub CTO Tom Preston-Werner</a></li>
     <li><span>27 Apr 2010</span> &raquo; <a href="http://www.youtube.com/watch?v=weF-_dLYrzw">The Next Web 2010: Interview about Gravatar and Online Reputation</a></li>
     <li><span>27 Apr 2010</span> &raquo; <a href="http://ontwik.com/github/tom-werner-co-founder-of-github/">TNW 2010: What I Learned From Bootstrapping a Side Project Into GitHub</a></li>
-    <li><span>19 Nov 2009</span> &raquo; <a href="http://rubyconf2009.confreaks.com/19-nov-2009-10-25-bert-and-ernie-scaling-your-ruby-site-with-erlang-tom-preston-werner.html">RubyConf 2009 Talk: BERT and Ernie: Scaling your Ruby site with Erlang</a></li>
+    <li><span>19 Nov 2009</span> &raquo; <a href="http://confreaks.com/videos/160-rubyconf2009-bert-and-ernie-scaling-your-ruby-site-with-erlang">RubyConf 2009 Talk: BERT and Ernie: Scaling your Ruby site with Erlang</a></li>
     <li><span>21 Aug 2009</span> &raquo; <a href="http://www.linux-mag.com/cache/7486/1.html">Linux Magazine: The GitHub Hall of Fame - Jekyll Review</a></li>
     <li><span>27 Jul 2009</span> &raquo; <a href="http://developer.yahoo.com/yui/theater/video.php?v=prestonwerner-github">Yahoo Developer Talk: Git, GitHub, and Social Coding</a></li>
     <li><span>22 Jul 2009</span> &raquo; <a href="http://www.viddler.com/explore/GreggPollack/videos/25/44">Envy Labs: 5 Days of OSCON Interview</a></li>
@@ -52,8 +52,8 @@ title: Tom Preston-Werner
     <li><span>23 Apr 2009</span> &raquo; <a href="http://images.businessweek.com/ss/09/04/0421_best_young_entrepreneurs/17.htm">BusinessWeek: Best Young Tech Entrepreneurs of 2009</a></li>
     <li><span>17 Jan 2009</span> &raquo; <a href="http://www.infoq.com/presentations/preston-werner-conceptual-algorithms">RubyFringe 2008: Conceptual Algorithms</a></li>
     <li><span>09 Oct 2008</span> &raquo; <a href="http://www.infoq.com/interviews/preston-werner-powerset-github-ruby">InfoQ: Tom Preston-Werner on Powerset, GitHub, Ruby and Erlang</a></li>
-    <li><span>11 Jul 2008</span> &raquo; <a href="http://www.rubyology.com/podcasts/show/67">Rubyology 65: Powerset Stars 2 of 2</a></li>
-    <li><span>05 Jul 2008</span> &raquo; <a href="http://www.rubyology.com/podcasts/show/66">Rubyology 65: Powerset Stars 1 of 2</a></li>
+    <li><span>11 Jul 2008</span> &raquo; <a href="http://www.rubyology.com/podcasts/67">Rubyology 67: Powerset Stars 2 of 2</a></li>
+    <li><span>05 Jul 2008</span> &raquo; <a href="http://www.rubyology.com/podcasts/66">Rubyology 66: Powerset Stars 1 of 2</a></li>
     <li><span>13 Jun 2008</span> &raquo; <a href="http://web20show.com/episodes/web20show-ep45-github">Web 2.0 Show: GitHub (Tom Preston-Werner &amp; Chris Wanstrath)</a></li>
     <li><span>02 Jun 2008</span> &raquo; <a href="http://www.vimeo.com/1104583">Gregg Pollack: Dave Fayram and Tom Preston-Werner at RailsConf</a></li>
     <li><span>29 May 2008</span> &raquo; <a href="http://en.oreilly.com/rails2008/public/schedule/speaker/2520">RailsConf 08: Two talks</a></li>


### PR DESCRIPTION
Noticed one link was broken, so I did a sweep and fixed a few more. 

There are also two broken links (on index.html) for which I couldn't find the original content. Looks like the blogs that hosted them were completely removed, although the main sites that hosted the blogs are still around:
- http://lambdaphant.com/blog/interview-with-tom-preston-werner-from-github (main site http://lambdaphant.com/ is still alive)
- http://joshuaink2006.johnoxton.co.uk/blog/240/seven-and-a-half-questions-for-tom-werner (main site http://johnoxton.co.uk/ is still alive)

Cheers!
