### PR TITLE
fixed Startup School 2012 link

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ title: Tom Preston-Werner
   <h1>Other Interviews, Talks, Etc</h1>
   <ul class="posts">
     <li><span>28 Dec 2012</span> &raquo; <a href="http://bits.blogs.nytimes.com/2012/12/28/github-has-big-dreams-for-open-source-software-and-more/">Article: NYTimes - Dreams of ‘Open’ Everything</a></li>
-    <li><span>20 Oct 2012</span> &raquo; <a href="http://startupschool.org/2012/preston_werner/">Video: Startup School 2012 - People, Product, Philosophy</a></li>
+    <li><span>20 Oct 2012</span> &raquo; <a href="http://www.youtube.com/watch?v=P9jjDpWzsUI">Video: Startup School 2012 - People, Product, Philosophy</a></li>
     <li><span>27 Sep 2012</span> &raquo; <a href="http://www.youtube.com/watch?v=Ln-B_fs9QMY&feature=youtu.be">Video (Panel): Orrick - How to Build a Great Startup Culture</a></li>
     <li><span>18 Jun 2012</span> &raquo; <a href="http://gigaom.com/cloud/10-innovators-changing-the-game-for-internet-infrastructure/7/">Article: GigaOm - 10 Innovators Changing the Game for Internet Infrastructure</a></li>
     <li><span>02 Dec 2011</span> &raquo; <a href="http://vimeo.com/35640883">Video: Northern Lights Conference - Leveling Up</a></li>


### PR DESCRIPTION
`http://startupschool.org/2012/preston_werner/` not found, changed to direct link to YouTube.
